### PR TITLE
Update migrating-from-docker-standalone-to-teable-enterprise.md

### DIFF
--- a/deployment/migrating-from-docker-standalone-to-teable-enterprise.md
+++ b/deployment/migrating-from-docker-standalone-to-teable-enterprise.md
@@ -16,8 +16,6 @@ Before starting the upgrade, make sure to backup your data:
 Replace your old docker-compose.yaml with the following:
 
 ```yaml
-version: '3.9'
-
 services:
   teable:
     image: ghcr.io/teableio/teable-ee:latest


### PR DESCRIPTION
Removing Version Number from the first line of docker-compose.yaml in Step 2. The version flag is now obsolete.